### PR TITLE
Calculate start and end times at scrape time

### DIFF
--- a/cmd/loki_exporter/exporter.go
+++ b/cmd/loki_exporter/exporter.go
@@ -196,8 +196,8 @@ func (e *Exporter) getQueries() error {
 		requestURL := exporterConfig.Loki.ListenAddress + "/api/prom/query?"
 		requestURL += "query=" + query.Query
 		requestURL += "&limit=" + strconv.FormatInt(query.Limit, 10)
-		requestURL += "&start=" + query.Start
-		requestURL += "&end=" + query.End
+		requestURL += "&start=" + formatQueryTime(query.Start)
+		requestURL += "&end=" + formatQueryTime(query.End)
 		requestURL += "&direction=" + query.Direction
 		requestURL += "&regexp=" + query.Regexp
 
@@ -255,4 +255,8 @@ func (e *Exporter) getQueries() error {
 	}
 
 	return nil
+}
+
+func formatQueryTime(t time.Duration) string {
+	return strconv.FormatInt(time.Now().Add(t).UnixNano(), 10)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"io/ioutil"
-	"strconv"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -27,13 +26,13 @@ type Config struct {
 	} `yaml:"metrics"`
 
 	Queries []struct {
-		Name      string `yaml:"name"`
-		Query     string `yaml:"query"`
-		Limit     int64  `yaml:"limit"`
-		Start     string `yaml:"start"`
-		End       string `yaml:"end"`
-		Direction string `yaml:"direction"`
-		Regexp    string `yaml:"regexp"`
+		Name      string        `yaml:"name"`
+		Query     string        `yaml:"query"`
+		Limit     int64         `yaml:"limit"`
+		Start     time.Duration `yaml:"start"`
+		End       time.Duration `yaml:"end"`
+		Direction string        `yaml:"direction"`
+		Regexp    string        `yaml:"regexp"`
 	} `yaml:"queries"`
 }
 
@@ -64,26 +63,13 @@ func (c *Config) LoadConfig(file string) error {
 			c.Queries[index].Limit = -1
 		}
 
-		if c.Queries[index].Start == "" {
-			c.Queries[index].Start = "-24h"
+		if c.Queries[index].Start == 0 {
+			c.Queries[index].Start = time.Hour * -24
 		}
 
-		if c.Queries[index].End == "" {
-			c.Queries[index].End = "0s"
+		if c.Queries[index].End == 0 {
+			c.Queries[index].End = time.Second * 0
 		}
-
-		startDuration, err := time.ParseDuration(c.Queries[index].Start)
-		if err != nil {
-			return err
-		}
-
-		endDuration, err := time.ParseDuration(c.Queries[index].End)
-		if err != nil {
-			return err
-		}
-
-		c.Queries[index].Start = strconv.FormatInt(time.Now().Add(startDuration).UnixNano(), 10)
-		c.Queries[index].End = strconv.FormatInt(time.Now().Add(endDuration).UnixNano(), 10)
 	}
 
 	return nil


### PR DESCRIPTION
Previously the start and end times have been set at the exporter start
during the config parsing. This does not work properly if the exporter
is a long running process like as it usually is. Also uses time.Duration
as the for start/end to avoid unnecessary type conversions.